### PR TITLE
Bug fixing, editing documentation:

### DIFF
--- a/projects/ngx-mfe/package.json
+++ b/projects/ngx-mfe/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ngx-mfe",
-	"version": "1.0.7",
+	"version": "1.0.8",
 	"license": "MIT",
 	"repository": {
 		"type": "GitHub",

--- a/projects/ngx-mfe/src/lib/injection-tokens/options.token.ts
+++ b/projects/ngx-mfe/src/lib/injection-tokens/options.token.ts
@@ -3,4 +3,4 @@ import { InjectionToken } from '@angular/core';
 /**
  * InjectionToken of options.
  */
-export const OPTIONS = new InjectionToken<string>('@nx-mfe/client/mfe/OPTIONS');
+export const NGX_MFE_OPTIONS = new InjectionToken<string>('ngx-mfe/options');

--- a/projects/ngx-mfe/src/lib/interfaces/index.ts
+++ b/projects/ngx-mfe/src/lib/interfaces/index.ts
@@ -1,4 +1,4 @@
 export * from './loaded-mfe.interface';
 export * from './mfe-config.interface';
-export * from './mfe-module-root-options.interface';
+export * from './ngx-mfe-options.interface';
 

--- a/projects/ngx-mfe/src/lib/interfaces/ngx-mfe-options.interface.ts
+++ b/projects/ngx-mfe/src/lib/interfaces/ngx-mfe-options.interface.ts
@@ -3,7 +3,7 @@ import { IMfeConfig } from './mfe-config.interface';
 /**
  * Global options.
  */
-export interface IMfeModuleRootOptions {
+export interface NgxMfeOptions {
 	/**
 	 * Options for each micro-frontend app.
 	 */
@@ -14,12 +14,6 @@ export interface IMfeModuleRootOptions {
 	 */
 	preload?: string[];
 	/**
-	 * The delay between displaying the contents of the bootloader and the micro-frontend.
-	 *
-	 * This is to avoid flickering when the micro-frontend loads very quickly.
-	 */
-	delay?: number;
-	/**
 	 * Loader micro-frontend.
 	 *
 	 * Shows when load bundle of another micro-frontend.
@@ -27,6 +21,12 @@ export interface IMfeModuleRootOptions {
 	 * For better UX, add this micro-frontend to {@link preload} array.
 	 */
 	loader?: string;
+	/**
+	 * The delay between displaying the contents of the bootloader and the micro-frontend.
+	 *
+	 * This is to avoid flickering when the micro-frontend loads very quickly.
+	 */
+	loaderDelay?: number;
 	/**
 	 * Fallback micro-frontend.
 	 *

--- a/projects/ngx-mfe/src/lib/mfe.module.ts
+++ b/projects/ngx-mfe/src/lib/mfe.module.ts
@@ -2,8 +2,8 @@ import { loadRemoteEntry } from '@angular-architects/module-federation';
 import { ModuleWithProviders, NgModule } from '@angular/core';
 import { MfeOutletDirective } from './directives';
 import { validateMfeString } from './helpers';
-import { OPTIONS } from './injection-tokens';
-import { IMfeModuleRootOptions } from './interfaces';
+import { NGX_MFE_OPTIONS } from './injection-tokens';
+import { NgxMfeOptions } from './interfaces';
 import { MfeRegistry } from './registry';
 
 /**
@@ -23,7 +23,7 @@ export class MfeModule {
 	 * Sets global configuration of Mfe lib.
 	 * @param options Object of options.
 	 */
-	public static forRoot(options: IMfeModuleRootOptions): ModuleWithProviders<MfeModule> {
+	public static forRoot(options: NgxMfeOptions): ModuleWithProviders<MfeModule> {
 		const mfeRegistry = MfeRegistry.getInstance(options.mfeConfig);
 		const loadMfeBundle = loadMfeBundleWithMfeRegistry(mfeRegistry);
 
@@ -42,7 +42,7 @@ export class MfeModule {
 					useValue: mfeRegistry,
 				},
 				{
-					provide: OPTIONS,
+					provide: NGX_MFE_OPTIONS,
 					useValue: options,
 				},
 			],

--- a/projects/ngx-mfe/src/lib/types/mfe-outlet-outputs.ts
+++ b/projects/ngx-mfe/src/lib/types/mfe-outlet-outputs.ts
@@ -1,4 +1,4 @@
 /**
  * Outputs that projects to micro-frontend component.
  */
-export type MfeOutletOutputs = Record<string, (event: unknown) => void>;
+ export type MfeOutletOutputs = Record<string, (...args: any) => void>;


### PR DESCRIPTION
Fixed bug with `outputs` prop in `MfeOutletDirective`;

Fixed bug with `loaderDelay` in `MfeOutletDirective`, before the fix, the `loaderDelay` timer was first waited, and then the MFE was loaded.
The current behavior of `loaderDelay` is that the delay timer and MFE bundle loading start at the same time.
The `loaderDelay` property sets the minimum loader display time in ms;

Edited and improved documentation in README.md file;

`IMfeModuleRootOptions` interface renamed to `NgxMfeOptions`;

Property `delay` in the `NgxMfeOptions` renamed to `loaderDelay`;

`OPTIONS` injection token renamed to `NGX_MFE_OPTIONS`;