### PR TITLE
v15.1.0 Added ability to load MfeConfig asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ ngx-mfe                               | v1.0.0  | v1.0.5  | v2.0.0  | v3.0.0  |
 Angular                               | v12.0.0 | v13.0.0 | v13.0.0 | v14.0.0 |
 @angular-architects/module-federation | v12.0.0 | v14.0.0 | v14.0.0 | v14.3.0 |
 
+**Since v15.0.0 version of ngx-mfe library is compatible with Angular version**
+
 ## Motivation
 
 When Webpack 5 came along and the Module Federation plugin, it became possible to separately compile and deploy code for front-end applications, thereby breaking up a monolithic front-end application into separate and independent **M**icro**F**ront**E**nd (MFE) applications.
@@ -211,7 +213,15 @@ export class Feature1Module {}
 
 ### List of all available options:
 
-- **mfeConfig** - object where **key** is micro-frontend app name specified in `ModuleFederationPlugin` (webpack.config.js) and **value** is remoteEntryUrl string. All data will be sets to [MfeRegistry](https://github.com/dkhrunov/ngx-mfe/blob/master/projects/ngx-mfe/src/lib/registry/mfe-registry.ts).
+- **mfeConfig**
+
+  ----------------
+
+  **Sync variant of providing mfeConfig:**
+  
+  ----------------
+
+  object where **key** is micro-frontend app name specified in `ModuleFederationPlugin` (webpack.config.js) and **value** is remoteEntryUrl string. All data will be sets to [MfeRegistry](https://github.com/dkhrunov/ngx-mfe/blob/master/projects/ngx-mfe/src/lib/registry/mfe-registry.ts).
 
 	**Key** it's the name same specified in webpack.config.js of MFE (Remote) in option name in `ModuleFederationPlugin`.
 
@@ -223,20 +233,59 @@ export class Feature1Module {}
   
 	Example <http://localhost:4201/remoteEntry.js>
 
-	You can get `MfeRegistry` from DI:
+  >	(Deprecated from v15.1.0) You can get `MfeRegistry` from DI :
+  >
+  >	```typescript
+  >	class AppComponent {
+  >
+  >		constructor(public mfeRegistry: MfeRegistry) {}
+  >	}
+  >	```
+
+	You can even get instace of `MfeRegistry` like this:
 
 	```typescript
-	class AppComponent {
-
-		constructor(public mfeRegistry: MfeRegistry) {}
-	}
+	const mfeRegistry: MfeRegistry = MfeRegistry.instace;
 	```
 
-	Or you can even get `MfeRegistry` without DI, because this class is written as a singleton:
+  ----------------
+  
+  **Async variant of providing mfeConfig:**
+  
+  ----------------
 
-	```typescript
-	const mfeRegistry: MfeRegistry = MfeRegistry.getInstance();
+  > NOTE: The application will wait for initialization and completes when the promise resolves or the observable completes.
+  >
+  > Because under the hood used `APP_INITIALIZER` injection token with useFactory that returns Observale or Promise. [More about `APP_INITIALIZER`](https://angular.io/api/core/APP_INITIALIZER)
+
+
+  Also you can provide mfeConfig with loading it from external resource as `Observale<MfeConfig>` or `Promise<MfeConfig>`, for this you should provide this type of object:
+
+  ```typescript
+	type NgxMfeAsyncConfig = {
+    /**
+      * A function to invoke to load a `MfeConfig`. The function is invoked with
+      * resolved values of `token`s in the `deps` field.
+      */
+    useLoader: (...deps: any[]) => Observable<NgxMfeSyncConfig> | Promise<NgxMfeSyncConfig>;
+    /**
+      * A list of `token`s to be resolved by the injector. The list of values is then
+      * used as arguments to the `useLoader` function.
+      */
+    deps?: any[];
+  };
 	```
+
+  For example:
+
+  ```typescript
+  mfeConfig: {
+	 	useLoader:  (http: HttpClient): Observable<MfeConfig> =>
+      http.get<MfeConfig>('/manifest.json'),
+    deps: [HttpClient]
+  },
+  ```
+
 
 - **preload** (Optional) - a list of micro-frontend names, their bundles (remoteEntry.js) will be loaded and saved in the cache when the application starts.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mfe",
-  "version": "3.0.1",
+  "version": "15.1.0",
   "license": "MIT",
   "repository": {
     "type": "GitHub",

--- a/projects/ngx-mfe/README.md
+++ b/projects/ngx-mfe/README.md
@@ -21,10 +21,12 @@ Have problems with updates? Check out the  [migration guides](../../migration-gu
 - [Changelog](#changelog)
 
 ## Version Compliance
-ngx-mfe                               | v1.0.0  | v1.0.5  | v2.0.0  | v3.0.0  | v15.0.0 |
---------------------------------------| ------- | ------- | ------- | ------- | ------- |
-Angular                               | v12.0.0 | v13.0.0 | v13.0.0 | v14.0.0 | v15.0.0 |
-@angular-architects/module-federation | v12.0.0 | v14.0.0 | v14.0.0 | v14.3.0 | v15.0.0 |
+ngx-mfe                               | v1.0.0  | v1.0.5  | v2.0.0  | v3.0.0  |
+--------------------------------------| ------- | ------- | ------- | ------- |
+Angular                               | v12.0.0 | v13.0.0 | v13.0.0 | v14.0.0 |
+@angular-architects/module-federation | v12.0.0 | v14.0.0 | v14.0.0 | v14.3.0 |
+
+**Since v15.0.0 version of ngx-mfe library is compatible with Angular version**
 
 ## Motivation
 
@@ -211,7 +213,15 @@ export class Feature1Module {}
 
 ### List of all available options:
 
-- **mfeConfig** - object where **key** is micro-frontend app name specified in `ModuleFederationPlugin` (webpack.config.js) and **value** is remoteEntryUrl string. All data will be sets to [MfeRegistry](https://github.com/dkhrunov/ngx-mfe/blob/master/projects/ngx-mfe/src/lib/registry/mfe-registry.ts).
+- **mfeConfig**
+
+  ----------------
+
+  **Sync variant of providing mfeConfig:**
+  
+  ----------------
+
+  object where **key** is micro-frontend app name specified in `ModuleFederationPlugin` (webpack.config.js) and **value** is remoteEntryUrl string. All data will be sets to [MfeRegistry](https://github.com/dkhrunov/ngx-mfe/blob/master/projects/ngx-mfe/src/lib/registry/mfe-registry.ts).
 
 	**Key** it's the name same specified in webpack.config.js of MFE (Remote) in option name in `ModuleFederationPlugin`.
 
@@ -223,20 +233,59 @@ export class Feature1Module {}
   
 	Example <http://localhost:4201/remoteEntry.js>
 
-	You can get `MfeRegistry` from DI:
+  >	(Deprecated from v15.1.0) You can get `MfeRegistry` from DI :
+  >
+  >	```typescript
+  >	class AppComponent {
+  >
+  >		constructor(public mfeRegistry: MfeRegistry) {}
+  >	}
+  >	```
+
+	You can even get instace of `MfeRegistry` like this:
 
 	```typescript
-	class AppComponent {
-
-		constructor(public mfeRegistry: MfeRegistry) {}
-	}
+	const mfeRegistry: MfeRegistry = MfeRegistry.instace;
 	```
 
-	Or you can even get `MfeRegistry` without DI, because this class is written as a singleton:
+  ----------------
+  
+  **Async variant of providing mfeConfig:**
+  
+  ----------------
 
-	```typescript
-	const mfeRegistry: MfeRegistry = MfeRegistry.getInstance();
+  > NOTE: The application will wait for initialization and completes when the promise resolves or the observable completes.
+  >
+  > Because under the hood used `APP_INITIALIZER` injection token with useFactory that returns Observale or Promise. [More about `APP_INITIALIZER`](https://angular.io/api/core/APP_INITIALIZER)
+
+
+  Also you can provide mfeConfig with loading it from external resource as `Observale<MfeConfig>` or `Promise<MfeConfig>`, for this you should provide this type of object:
+
+  ```typescript
+	type NgxMfeAsyncConfig = {
+    /**
+      * A function to invoke to load a `MfeConfig`. The function is invoked with
+      * resolved values of `token`s in the `deps` field.
+      */
+    useLoader: (...deps: any[]) => Observable<NgxMfeSyncConfig> | Promise<NgxMfeSyncConfig>;
+    /**
+      * A list of `token`s to be resolved by the injector. The list of values is then
+      * used as arguments to the `useLoader` function.
+      */
+    deps?: any[];
+  };
 	```
+
+  For example:
+
+  ```typescript
+  mfeConfig: {
+	 	useLoader:  (http: HttpClient): Observable<MfeConfig> =>
+      http.get<MfeConfig>('/manifest.json'),
+    deps: [HttpClient]
+  },
+  ```
+
 
 - **preload** (Optional) - a list of micro-frontend names, their bundles (remoteEntry.js) will be loaded and saved in the cache when the application starts.
 

--- a/projects/ngx-mfe/package.json
+++ b/projects/ngx-mfe/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ngx-mfe",
-	"version": "15.0.0",
+	"version": "15.1.0",
 	"license": "MIT",
 	"repository": {
 		"type": "GitHub",

--- a/projects/ngx-mfe/src/lib/directives/mfe-outlet.directive.ts
+++ b/projects/ngx-mfe/src/lib/directives/mfe-outlet.directive.ts
@@ -16,8 +16,8 @@ import {
 import { EChangesStrategy, TrackChanges } from '../decorators';
 import { delay, LoadMfeOptions } from '../helpers';
 import { NGX_MFE_OPTIONS } from '../injection-tokens';
-import { isRemoteComponentWithModule, RemoteComponentWithModule, NgxMfeOptions, RemoteComponent, StandaloneRemoteComponent } from '../interfaces';
-import { DynamicComponentBinding, RemoteComponentsCache, RemoteComponentLoader } from '../services';
+import { isRemoteComponentWithModule, NgxMfeOptions, RemoteComponent, RemoteComponentWithModule, StandaloneRemoteComponent } from '../interfaces';
+import { DynamicComponentBinding, RemoteComponentLoader, RemoteComponentsCache } from '../services';
 import { MfeOutletInputs, MfeOutletOutputs } from '../types';
 
 /**

--- a/projects/ngx-mfe/src/lib/helpers/load-mfe.ts
+++ b/projects/ngx-mfe/src/lib/helpers/load-mfe.ts
@@ -1,6 +1,7 @@
-import { Type } from '@angular/core';
 import { loadRemoteModule, LoadRemoteModuleOptions } from '@angular-architects/module-federation';
+import { Type } from '@angular/core';
 
+import { firstValueFrom } from 'rxjs';
 import { MfeRegistry } from '../registry';
 
 /**
@@ -32,7 +33,7 @@ export async function loadMfe<T = unknown>(
 	options: LoadMfeOptions = loadMfeDefaultOptions
 ): Promise<Type<T>> {
   const _options: LoadMfeOptions = { ...loadMfeDefaultOptions, ...options };
-	const remoteEntry = MfeRegistry.getInstance().getMfeRemoteEntry(remoteApp);
+  const remoteEntry = await firstValueFrom(MfeRegistry.instance.getMfeRemoteEntry(remoteApp));
 	const loadRemoteModuleOptions: LoadRemoteModuleOptions =
 		_options.type === 'module'
 			? { type: _options.type, remoteEntry, exposedModule }

--- a/projects/ngx-mfe/src/lib/injection-tokens/options.token.ts
+++ b/projects/ngx-mfe/src/lib/injection-tokens/options.token.ts
@@ -1,6 +1,7 @@
 import { InjectionToken } from '@angular/core';
+import { NgxMfeOptions } from '../interfaces';
 
 /**
  * InjectionToken of options.
  */
-export const NGX_MFE_OPTIONS = new InjectionToken<string>('ngx-mfe/options');
+export const NGX_MFE_OPTIONS = new InjectionToken<NgxMfeOptions>('ngx-mfe/options');

--- a/projects/ngx-mfe/src/lib/interfaces/ngx-mfe-options.interface.ts
+++ b/projects/ngx-mfe/src/lib/interfaces/ngx-mfe-options.interface.ts
@@ -1,14 +1,44 @@
+import { Observable } from 'rxjs';
 import { MfeConfig } from './mfe-config.interface';
 import { RemoteComponent } from './remote-component.interface';
+
+/**
+ * Sync list of available micro-frontends.
+ */
+export type NgxMfeSyncConfig = MfeConfig;
+
+/**
+ * Async list of available micro-frontends.
+ */
+export type NgxMfeAsyncConfig = {
+   /**
+    * A function to invoke to load a `MfeConfig`. The function is invoked with
+    * resolved values of `token`s in the `deps` field.
+    */
+  useLoader: (...deps: any[]) => Observable<NgxMfeSyncConfig> | Promise<NgxMfeSyncConfig>;
+   /**
+    * A list of `token`s to be resolved by the injector. The list of values is then
+    * used as arguments to the `useLoader` function.
+    */
+  deps?: any[];
+};
+
+/**
+ * Type of sync / async list of available micro-frontends.
+ */
+export type NgxMfeConfigOption = NgxMfeSyncConfig | NgxMfeAsyncConfig;
+
+/**
+ * Type guard check that NgxMfeConfig is async list of available micro-frontends.
+ */
+export const isNgxMfeConfigAsync = (config: NgxMfeConfigOption): config is NgxMfeAsyncConfig => {
+	return Object.prototype.hasOwnProperty.call(config, 'useLoader');
+}
 
 /**
  * Global options.
  */
 export interface NgxMfeOptions {
-	/**
-	 * Options for each micro-frontend app.
-	 */
-	mfeConfig: MfeConfig;
 	/**
    * List of names of remote appls, declared apps will be downloaded immediately and stored in the cache.
 	 */
@@ -36,4 +66,14 @@ export interface NgxMfeOptions {
 	 * For better UX, add this micro-frontend to {@link preload} array.
 	 */
 	fallback?: RemoteComponent;
+}
+
+/**
+ * Options forRoot configuration of `NgxMfeModule`
+ */
+export type NgxMfeForRootOptions = NgxMfeOptions & {
+  /**
+   * List of available micro-frontends.
+	 */
+  mfeConfig: NgxMfeConfigOption;
 }

--- a/projects/ngx-mfe/src/lib/registry/mfe-registry.ts
+++ b/projects/ngx-mfe/src/lib/registry/mfe-registry.ts
@@ -1,43 +1,53 @@
+import { map, Observable, ReplaySubject, take } from 'rxjs';
 import { MfeConfig } from '../interfaces';
 
 /**
  * Registry of micro-frontends apps.
  */
 export class MfeRegistry {
-	private static _instance: MfeRegistry;
-	private readonly _mfeConfig: MfeConfig;
+  private static _instance: MfeRegistry;
 
-	private constructor(mfeConfig: MfeConfig) {
-		this._mfeConfig = mfeConfig;
-	}
+  private readonly _mfeConfig$ = new ReplaySubject<MfeConfig>(1);
 
-	/**
-	 * Get instance of the MfeRegistry
-	 */
-	public static getInstance(mfeConfig?: MfeConfig): MfeRegistry {
-		if (!MfeRegistry._instance) {
-			if (!mfeConfig)
-				throw new Error(
-					'MfeConfig should be provided for first time used MfeRegistry.getInstance(mfeConfig)'
-				);
+  /**
+   * Get instance of the MfeRegistry
+   */
+  public static get instance(): MfeRegistry {
+    if (!MfeRegistry._instance) {
+      MfeRegistry._instance = new MfeRegistry();
+    }
 
-			MfeRegistry._instance = new MfeRegistry(mfeConfig);
-		}
+    return MfeRegistry._instance;
+  }
 
-		return MfeRegistry._instance;
-	}
+  private constructor() {}
 
-	/**
-	 * Get the remote entry URL the micro-frontend app
-	 * @param mfeApp Micro-frontend app name
-	 */
-	public getMfeRemoteEntry(mfeApp: string): string {
-		const remoteEntry = this._mfeConfig[mfeApp];
+  /**
+   * Set config.
+   * @param config Micro-frontends config
+   */
+  public setMfeConfig(config: MfeConfig): void {
+    this._mfeConfig$.next(config);
+  }
 
-		if (!remoteEntry) {
-			throw new Error(`'${mfeApp}' micro-frontend is not registered in the MfeRegistery using MfeModule.forRoot({ mfeConfig })`);
-		}
+  /**
+   * Get the remote entry URL the micro-frontend app
+   * @param mfeApp Micro-frontend app name
+   */
+  public getMfeRemoteEntry(mfeApp: string): Observable<string> {
+    return this._mfeConfig$.pipe(
+      take(1),
+      map((config) => {
+        const remoteEntry = config[mfeApp];
 
-		return remoteEntry;
-	}
+        if (!remoteEntry) {
+          throw new Error(
+            `'${mfeApp}' micro-frontend is not registered in the MfeRegistery using MfeModule.forRoot({ mfeConfig })`
+          );
+        }
+
+        return remoteEntry;
+      })
+    );
+  }
 }


### PR DESCRIPTION
**Features:**
- Added ability to load MfeConfig asynchronously. [Issue - #18]

**Fixed:**
- Fixed type of `NGX_MFE_OPTIONS` form `InjectionToken<string>` to `InjectionToken<NgxMfeOptions>`.

**Breaking changes:** 
- Renamed MfeModule.forRoot() options from `NgxMfeOptions` to `NgxMfeForRootOptions`.
- Now `MfeRegistry` is no longer accessible from DI.
- Changed API of `MfeRegistry`:
  - changed method `public static getInstance(mfeConfig?: MfeConfig): MfeRegistry` to getter `public static get instance(): MfeRegistry`;
  - added method `public setMfeConfig(config: MfeConfig): void `.